### PR TITLE
Fix STR never refreshed

### DIFF
--- a/application/config.go
+++ b/application/config.go
@@ -93,7 +93,7 @@ func SaveSTR(file string, str *protocol.DirSTR) error {
 		return err
 	}
 
-	if err := utils.WriteFile(file, strBytes, 0600); err != nil {
+	if err := ioutil.WriteFile(file, strBytes, 0600); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When the server restarts, the chain should also be restarted. Yet, currently, the initial STR is not updated.